### PR TITLE
Update JDA to v3.3.1_286

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 buildscript {
-    ext.kotlin_version = '1.1.3-2'
+    ext.kotlin_version = '1.1.51'
 
     repositories {
         mavenCentral()
@@ -22,7 +22,7 @@ plugins {
 apply plugin: 'kotlin'
 
 group = 'gg.obsidian'
-version = '3.0.0'
+version = '3.0.1'
 description = """Bridge chat between Minecraft and Discord"""
 ext.url = 'https://github.com/the-obsidian/DiscordBridge'
 
@@ -39,9 +39,10 @@ repositories {
 dependencies {
     compile group: 'org.spigotmc', name: 'spigot-api', version: '1.12-R0.1-SNAPSHOT'
     compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.1.3-2'
-    compile group: 'net.dv8tion', name: 'JDA', version: '3.0.BETA2_108'
+    compile group: 'net.dv8tion', name: 'JDA', version: '3.3.1_286'
     compile group: 'com.michaelwflaherty', name: 'cleverbotapi', version: '1.0.1'
     compile group: 'org.pegdown', name:'pegdown', version: '1.6.0'
+    compile group: 'org.json', name: 'json', version: '20160810'
 
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compile files('libraries/dynmap-api-2.5-SNAPSHOT.jar')
@@ -69,6 +70,7 @@ build.finalizedBy(shadowJar)
 
 shadowJar {
     relocate 'org.apache', 'shadow.apache'
+    relocate 'org.json', 'shadow.json'
     classifier 'dist'
     dependencies {
         //noinspection GroovyAssignabilityCheck

--- a/src/main/kotlin/gg/obsidian/discordbridge/discord/Connection.kt
+++ b/src/main/kotlin/gg/obsidian/discordbridge/discord/Connection.kt
@@ -65,7 +65,7 @@ object Connection: Runnable {
         JDA.removeEventListener(listener)
         server = null
         channel = null
-        JDA.shutdown(false)
+        JDA.shutdown()
 
         //reconnect
         connect()


### PR DESCRIPTION
Fixes incompatibility issues with Discord's recent barrage of major updates.