### PR TITLE
Command forwarding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 apply plugin: 'kotlin'
 
 group = 'gg.obsidian'
-version = '3.0.1'
+version = '3.1.0-dev1'
 description = """Bridge chat between Minecraft and Discord"""
 ext.url = 'https://github.com/the-obsidian/DiscordBridge'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 buildscript {
-    ext.kotlin_version = '1.1.51'
+    ext.kotlin_version = '1.2.0'
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 apply plugin: 'kotlin'
 
 group = 'gg.obsidian'
-version = '3.1.0-dev1'
+version = '3.1.0'
 description = """Bridge chat between Minecraft and Discord"""
 ext.url = 'https://github.com/the-obsidian/DiscordBridge'
 

--- a/src/main/kotlin/gg/obsidian/discordbridge/Plugin.kt
+++ b/src/main/kotlin/gg/obsidian/discordbridge/Plugin.kt
@@ -136,7 +136,7 @@ class Plugin : JavaPlugin() {
     /**
      * Saves all default configs where configs do not exist and reloads data from file into memory
      */
-    fun updateConfig(version: String) {
+    private fun updateConfig(version: String) {
         this.saveDefaultConfig()
         config.options().copyDefaults(true)
         config.set("version", version)
@@ -182,7 +182,7 @@ class Plugin : JavaPlugin() {
         val users = Connection.listUsers()
         val found: Member = users.find { it.user.name + "#" + it.user.discriminator == discriminator } ?: return null
 
-        val ua: UserAlias = UserAlias(player.uniqueId, found.user.id)
+        val ua = UserAlias(player.uniqueId, found.user.id)
         requests.add(ua)
         val msg = "Minecraft user '${server.getOfflinePlayer(ua.mcUuid).name}' has requested to become associated with your Discord" +
                 " account. If this is you, respond '${Connection.JDA.selfUser.asMention} confirm'. If this is not" +
@@ -203,8 +203,8 @@ class Plugin : JavaPlugin() {
 
         var response = "${CC.YELLOW}Discord users:"
         for (user in users) {
-            if (user.user.isBot) response += "\n${CC.GOLD}- ${user.effectiveName} (Bot) | ${user.user.name}#${user.user.discriminator}${CC.RESET}"
-            else response += "\n${CC.YELLOW}- ${user.effectiveName} | ${user.user.name}#${user.user.discriminator}${CC.RESET}"
+            response += if (user.user.isBot) "\n${CC.GOLD}- ${user.effectiveName} (Bot) | ${user.user.name}#${user.user.discriminator}${CC.RESET}"
+            else "\n${CC.YELLOW}- ${user.effectiveName} | ${user.user.name}#${user.user.discriminator}${CC.RESET}"
         }
         return response.trim()
     }
@@ -218,25 +218,25 @@ class Plugin : JavaPlugin() {
             return "${CC.YELLOW}No Discord members could be found. Either server is empty or an error has occurred."
 
         var response = ""
-        if (onlineUsers.filter { it.onlineStatus == OnlineStatus.ONLINE }.isNotEmpty()) {
+        if (onlineUsers.any { it.onlineStatus == OnlineStatus.ONLINE }) {
             response += "\n${CC.DARK_GREEN}Online:${CC.RESET}"
             for (user in onlineUsers.filter { it.onlineStatus == OnlineStatus.ONLINE }) {
-                if (user.user.isBot) response += "\n${CC.DARK_GREEN}- ${user.effectiveName} (Bot)${CC.RESET}"
-                else response += "\n${CC.DARK_GREEN}- ${user.effectiveName}${CC.RESET}"
+                response += if (user.user.isBot) "\n${CC.DARK_GREEN}- ${user.effectiveName} (Bot)${CC.RESET}"
+                else "\n${CC.DARK_GREEN}- ${user.effectiveName}${CC.RESET}"
             }
         }
-        if (onlineUsers.filter { it.onlineStatus == OnlineStatus.IDLE }.isNotEmpty()) {
+        if (onlineUsers.any { it.onlineStatus == OnlineStatus.IDLE }) {
             response += "\n${CC.YELLOW}Idle:${CC.RESET}"
             for (user in onlineUsers.filter { it.onlineStatus == OnlineStatus.IDLE }) {
-                if (user.user.isBot) response += "\n${CC.YELLOW}- ${user.effectiveName} (Bot)${CC.RESET}"
-                else response += "\n${CC.YELLOW}- ${user.effectiveName}${CC.RESET}"
+                response += if (user.user.isBot) "\n${CC.YELLOW}- ${user.effectiveName} (Bot)${CC.RESET}"
+                else "\n${CC.YELLOW}- ${user.effectiveName}${CC.RESET}"
             }
         }
-        if (onlineUsers.filter { it.onlineStatus == OnlineStatus.DO_NOT_DISTURB }.isNotEmpty()) {
+        if (onlineUsers.any { it.onlineStatus == OnlineStatus.DO_NOT_DISTURB }) {
             response += "\n${CC.RED}Do Not Disturb:${CC.RESET}"
             for (user in onlineUsers.filter { it.onlineStatus == OnlineStatus.DO_NOT_DISTURB }) {
-                if (user.user.isBot) response += "\n${CC.RED}- ${user.effectiveName} (Bot)${CC.RESET}"
-                else response += "\n${CC.RED}- ${user.effectiveName}${CC.RESET}"
+                response += if (user.user.isBot) "\n${CC.RED}- ${user.effectiveName} (Bot)${CC.RESET}"
+                else "\n${CC.RED}- ${user.effectiveName}${CC.RESET}"
             }
         }
 

--- a/src/main/kotlin/gg/obsidian/discordbridge/UserAliasConfig.kt
+++ b/src/main/kotlin/gg/obsidian/discordbridge/UserAliasConfig.kt
@@ -13,7 +13,7 @@ object UserAliasConfig {
      */
     fun load(plugin: Plugin) {
         val list = plugin.users.data.getList("aliases")
-        if (list != null) aliases = list.checkItemsAre<UserAlias>() ?:
+        if (list != null) aliases = list.checkItemsAre() ?:
                 throw IllegalStateException("usernames.yml could not be read - list items are not properly formatted")
         else mutableListOf<UserAlias>()
     }
@@ -42,5 +42,5 @@ object UserAliasConfig {
      * A function to assert that all the items in a given list are of a specific type
      */
     @Suppress("UNCHECKED_CAST")
-    inline fun <reified T : Any> List<*>.checkItemsAre() = if (all { it is T }) this as List<T> else null
+    private inline fun <reified T : Any> List<*>.checkItemsAre() = if (all { it is T }) this as List<T> else null
 }

--- a/src/main/kotlin/gg/obsidian/discordbridge/commands/DiscordCommandSender.kt
+++ b/src/main/kotlin/gg/obsidian/discordbridge/commands/DiscordCommandSender.kt
@@ -1,0 +1,96 @@
+package gg.obsidian.discordbridge.commands
+
+import net.dv8tion.jda.core.entities.MessageChannel
+import org.bukkit.Bukkit
+import org.bukkit.Server
+import org.bukkit.command.CommandSender
+import org.bukkit.command.ConsoleCommandSender
+import org.bukkit.command.RemoteConsoleCommandSender
+import org.bukkit.permissions.Permission
+import org.bukkit.permissions.PermissionAttachment
+import org.bukkit.permissions.PermissionAttachmentInfo
+import org.bukkit.plugin.Plugin
+
+class DiscordCommandSender(val channel: MessageChannel) : RemoteConsoleCommandSender {
+
+    private val sender:ConsoleCommandSender = Bukkit.getServer().consoleSender
+
+    init {
+
+    }
+
+    override fun sendMessage(message: String?) {
+        channel.sendMessage(message).queue()
+    }
+
+    override fun sendMessage(messages: Array<out String>?) {
+        if (messages != null)
+            for (m in messages) channel.sendMessage(m)
+    }
+
+    override fun spigot(): CommandSender.Spigot {
+        return sender.spigot()
+    }
+
+    override fun addAttachment(plugin: Plugin?): PermissionAttachment {
+        return sender.addAttachment(plugin)
+    }
+
+    override fun addAttachment(plugin: Plugin?, ticks: Int): PermissionAttachment {
+        return sender.addAttachment(plugin, ticks)
+    }
+
+    override fun addAttachment(plugin: Plugin?, name: String?, value: Boolean): PermissionAttachment {
+        return sender.addAttachment(plugin, name, value)
+    }
+
+    override fun addAttachment(plugin: Plugin?, name: String?, value: Boolean, ticks: Int): PermissionAttachment {
+        return sender.addAttachment(plugin, name, value, ticks)
+    }
+
+    override fun getEffectivePermissions(): MutableSet<PermissionAttachmentInfo> {
+        return sender.effectivePermissions
+    }
+
+    override fun getName(): String {
+        return sender.name
+    }
+
+    override fun getServer(): Server {
+        return sender.server
+    }
+
+    override fun hasPermission(name: String?): Boolean {
+        return sender.hasPermission(name)
+    }
+
+    override fun hasPermission(perm: Permission?): Boolean {
+        return sender.hasPermission(perm)
+    }
+
+    override fun isOp(): Boolean {
+        return sender.isOp
+    }
+
+    override fun isPermissionSet(name: String?): Boolean {
+        return sender.isPermissionSet(name)
+    }
+
+    override fun isPermissionSet(perm: Permission?): Boolean {
+        return sender.isPermissionSet(perm)
+    }
+
+    override fun recalculatePermissions() {
+        return sender.recalculatePermissions()
+    }
+
+    override fun removeAttachment(attachment: PermissionAttachment?) {
+        return sender.removeAttachment(attachment)
+    }
+
+    override fun setOp(value: Boolean) {
+        return sender.setOp(value)
+    }
+
+
+}

--- a/src/main/kotlin/gg/obsidian/discordbridge/commands/annotations/BotCommand.kt
+++ b/src/main/kotlin/gg/obsidian/discordbridge/commands/annotations/BotCommand.kt
@@ -7,9 +7,9 @@ package gg.obsidian.discordbridge.commands.annotations
  * @param description a short string that describes the command's function
  * @param name an optional field to override the command's access name if it is not the same as the method name
  * @param relayTriggerMessage whether the message used to trigger this command should be relayed
- * @param ignoreExcessArguments if false, this command will fail if the invoker provides too many arguments
+ * @param squishExcessArgs if true, this command will put all extra args passed to it into a single string
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class BotCommand(val usage: String, val description: String, val name: String = "",
-                            val relayTriggerMessage: Boolean = true, val ignoreExcessArguments: Boolean = true)
+                            val relayTriggerMessage: Boolean = true, val squishExcessArgs: Boolean = false)

--- a/src/main/kotlin/gg/obsidian/discordbridge/commands/controllers/BotControllerManager.kt
+++ b/src/main/kotlin/gg/obsidian/discordbridge/commands/controllers/BotControllerManager.kt
@@ -73,7 +73,7 @@ class BotControllerManager(val plugin: Plugin) {
         if (methodParameters.isEmpty() || !methodParameters[0].type.isAssignableFrom(IEventWrapper::class.java)) return
 
         method.isAccessible = true
-        val parameters = (1..methodParameters.size - 1).mapTo(ArrayList<Class<*>>()) { methodParameters[it].type }
+        val parameters = (1 until methodParameters.size).mapTo(ArrayList<Class<*>>()) { methodParameters[it].type }
         val isTagged: Boolean = method.getAnnotation(TaggedResponse::class.java) != null
         val isPrivate: Boolean = method.getAnnotation(PrivateResponse::class.java) != null
         val command = Command(commandName, usage, annotation.description, parameters, annotation.relayTriggerMessage,
@@ -256,11 +256,11 @@ class BotControllerManager(val plugin: Plugin) {
 
             // If command is squishy, pack excess args into final string
             command.squishExcessArgs -> {
-                if (args.size == 1)
+                if (command.parameters.size == 1)
                     squishedArgs = arrayOf(args.joinToString(" "))
                 else {
-                    squishedArgs = args.sliceArray(0 until command.parameters.size)
-                    squishedArgs[command.parameters.size-1] = args.sliceArray(command.parameters.size until args.size).joinToString(" ")
+                    squishedArgs = args.sliceArray(0 until command.parameters.size-1)
+                    squishedArgs[command.parameters.size-1] = args.sliceArray(command.parameters.size-1 until args.size).joinToString(" ")
                 }
             }
 

--- a/src/main/kotlin/gg/obsidian/discordbridge/commands/controllers/BotControllerManager.kt
+++ b/src/main/kotlin/gg/obsidian/discordbridge/commands/controllers/BotControllerManager.kt
@@ -11,6 +11,7 @@ import gg.obsidian.discordbridge.utils.UtilFunctions.noSpace
 import gg.obsidian.discordbridge.utils.UtilFunctions.stripColor
 import gg.obsidian.discordbridge.utils.UtilFunctions.toDiscordChatMessage
 import gg.obsidian.discordbridge.utils.UtilFunctions.toMinecraftChatMessage
+import org.bukkit.Bukkit
 import java.lang.reflect.Method
 import java.util.*
 import java.util.logging.Level
@@ -110,6 +111,12 @@ class BotControllerManager(val plugin: Plugin) {
             val command = commands[commandName]
 
             if (command == null) {
+                // Attempt to run as a server command
+                val serverCommandSuccess = Bukkit.getServer().dispatchCommand(Bukkit.getServer().consoleSender, args.joinToString(" ").substring(Config.COMMAND_PREFIX.length))
+                if (serverCommandSuccess)
+                    return true
+
+
                 commandNotFound(event, commandName)
                 return false
             }
@@ -361,7 +368,6 @@ class BotControllerManager(val plugin: Plugin) {
      * message is not relayed to Minecraft
      */
     private fun relay(event: IEventWrapper, logIgnore: Boolean) {
-        plugin.logger.info("Entered relay. event: ${event.message}")
         when (event) {
             is AsyncPlayerChatEventWrapper -> {
                 var worldname = event.event.player.world.name

--- a/src/main/kotlin/gg/obsidian/discordbridge/commands/controllers/FunCommandsController.kt
+++ b/src/main/kotlin/gg/obsidian/discordbridge/commands/controllers/FunCommandsController.kt
@@ -29,7 +29,7 @@ class FunCommandsController(val plugin: Plugin) : IBotController {
      * @param event the incoming event object
      * @return the response string
      */
-    @BotCommand(name = "8ball", usage = "<question>", description = "Consult the Magic 8 Ball")
+    @BotCommand(name = "8ball", usage = "<question>", description = "Consult the Magic 8 Ball", squishExcessArgs = true)
     @TaggedResponse
     private fun eightBall(event: IEventWrapper): String {
         plugin.logDebug("user ${event.senderName} consults the Magic 8-Ball")
@@ -46,7 +46,7 @@ class FunCommandsController(val plugin: Plugin) : IBotController {
      * @return the response string
      */
     @BotCommand(name = "choose", usage = "<option>, <option>, ... (delimiters include ',', 'or', '|')",
-            description = "Have the bot choose between given options")
+            description = "Have the bot choose between given options", squishExcessArgs = true)
     @TaggedResponse
     private fun choose(event: IEventWrapper, query: String): String {
         plugin.logDebug("user ${event.senderName} needs a choice made")
@@ -100,7 +100,7 @@ class FunCommandsController(val plugin: Plugin) : IBotController {
      * @param thingToInsult the target of the insult
      * @return the response string
      */
-    @BotCommand(usage="<thing to insult>", description = "Make the bot insult something for you")
+    @BotCommand(usage="<thing to insult>", description = "Make the bot insult something for you", squishExcessArgs = true)
     private fun insult(event: IEventWrapper, thingToInsult: String): String {
         plugin.logDebug("user ${event.senderName} requests an insult against '$thingToInsult'")
         val responses = plugin.insult.data.getStringList("responses")
@@ -115,7 +115,7 @@ class FunCommandsController(val plugin: Plugin) : IBotController {
      * @param thingToRate the thing that will receive the rating
      * @return the response string
      */
-    @BotCommand(usage="<thing to be rated>", description = "Have the bot rate something for you")
+    @BotCommand(usage="<thing to be rated>", description = "Have the bot rate something for you", squishExcessArgs = true)
     @TaggedResponse
     private fun rate(event: IEventWrapper, thingToRate: String): String {
         plugin.logDebug("user ${event.senderName} requests a rating")
@@ -182,7 +182,7 @@ class FunCommandsController(val plugin: Plugin) : IBotController {
      * @return the response string
      */
     @TaggedResponse
-    @BotCommand(usage="<say something>", description = "Say something to Cleverbot")
+    @BotCommand(usage="<say something>", description = "Say something to Cleverbot", squishExcessArgs = true)
     private fun talk(event: IEventWrapper, query: String): String {
         plugin.logDebug("user ${event.senderName} invokes Cleverbot")
 

--- a/src/main/kotlin/gg/obsidian/discordbridge/commands/controllers/FunCommandsController.kt
+++ b/src/main/kotlin/gg/obsidian/discordbridge/commands/controllers/FunCommandsController.kt
@@ -80,11 +80,11 @@ class FunCommandsController(val plugin: Plugin) : IBotController {
 
         totalRespects += found!!.count
         val msg: String
-        if (found.message.contains("%u"))
-            msg = found.message.replace("%u", event.senderAsMention).replace("%t", totalRespects.toString())
-                .replace("%c", found.count.toString())
+        msg = if (found.message.contains("%u"))
+            found.message.replace("%u", event.senderAsMention).replace("%t", totalRespects.toString())
+                    .replace("%c", found.count.toString())
         else
-            msg = "${event.senderAsMention} | ${found.message}".replace("%t", totalRespects.toString())
+            "${event.senderAsMention} | ${found.message}".replace("%t", totalRespects.toString())
                     .replace("%c", found.count.toString())
 
         plugin.f.data.set("total-respects", totalRespects)
@@ -188,7 +188,7 @@ class FunCommandsController(val plugin: Plugin) : IBotController {
 
         if (Config.CLEVERBOT_KEY.isEmpty())
             return "You do not have an API key. Go to https://www.cleverbot.com/JDA/ for more information."
-        val bot: CleverBotQuery = CleverBotQuery(Config.CLEVERBOT_KEY, query)
+        val bot = CleverBotQuery(Config.CLEVERBOT_KEY, query)
         bot.sendRequest()
         return bot.response
     }

--- a/src/main/kotlin/gg/obsidian/discordbridge/discord/Connection.kt
+++ b/src/main/kotlin/gg/obsidian/discordbridge/discord/Connection.kt
@@ -15,7 +15,7 @@ import net.dv8tion.jda.core.entities.*
 object Connection: Runnable {
     lateinit var plugin: Plugin
     lateinit var JDA: JDA
-    lateinit var listener: Listener
+    private lateinit var listener: Listener
     var server: Guild? = null
     var channel: TextChannel? = null
 

--- a/src/main/kotlin/gg/obsidian/discordbridge/discord/Listener.kt
+++ b/src/main/kotlin/gg/obsidian/discordbridge/discord/Listener.kt
@@ -15,7 +15,7 @@ import net.dv8tion.jda.core.hooks.ListenerAdapter
  */
 class Listener(val plugin: Plugin) : ListenerAdapter() {
 
-    val controllerManager = BotControllerManager(plugin)
+    private val controllerManager = BotControllerManager(plugin)
 
     init {
         controllerManager.registerController(FunCommandsController(plugin), discordExclusive = true, chatExclusive = true)

--- a/src/main/kotlin/gg/obsidian/discordbridge/minecraft/CommandListener.kt
+++ b/src/main/kotlin/gg/obsidian/discordbridge/minecraft/CommandListener.kt
@@ -16,7 +16,7 @@ import org.bukkit.command.CommandSender
  */
 class CommandListener(val plugin: Plugin) : CommandExecutor {
 
-    val controllerManager = BotControllerManager(plugin)
+    private val controllerManager = BotControllerManager(plugin)
 
     init {
         controllerManager.registerController(FunCommandsController(plugin), minecraftExclusive = true)

--- a/src/main/kotlin/gg/obsidian/discordbridge/minecraft/EventListener.kt
+++ b/src/main/kotlin/gg/obsidian/discordbridge/minecraft/EventListener.kt
@@ -73,7 +73,6 @@ class EventListener(val plugin: Plugin): Listener {
         plugin.server.scheduler.runTaskAsynchronously(plugin, { controllerManager.dispatchMessage(wrapper) })
 
         event.message = MarkdownToMinecraftSeralizer().toMinecraft(plugin.pegDownProc.parseMarkdown(event.message.toCharArray()))
-        plugin.logger.info("Seralized! (synchronous)")
     }
 
     /**

--- a/src/main/kotlin/gg/obsidian/discordbridge/minecraft/EventListener.kt
+++ b/src/main/kotlin/gg/obsidian/discordbridge/minecraft/EventListener.kt
@@ -31,7 +31,7 @@ import org.bukkit.ChatColor as CC
  */
 class EventListener(val plugin: Plugin): Listener {
 
-    val controllerManager = BotControllerManager(plugin)
+    private val controllerManager = BotControllerManager(plugin)
 
     init {
         controllerManager.registerController(FunCommandsController(plugin), chatExclusive = true)


### PR DESCRIPTION
Adds the command forwarding feature requested in #54.

- Spigot commands can be invoked from Discord using either @mention or prefix syntax as if they were any other command
- Theoretically works with any command, either built-in or provided by installed plugins, as long as they can be ran as console (I tested with a number of commands, but I wouldn't call it rigorously tested)
- Command output (if any) should be relayed back to Discord
- If logAdminCommands is true, commands sent from Discord in this way will show up as executed by `[Rcon]` (remote console)
- Commands native to DiscordBridge take precedence over any other commands with the same name (notably `/help`, which is a Spigot command)
